### PR TITLE
https proxy announcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +82,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bumpalo"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +112,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,10 +142,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
 name = "custom_error"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f8a51dd197fa6ba5b4dc98a990a43cc13693c23eb0089ebb0fcc1f04152bca6"
+
+[[package]]
+name = "cxx"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures"
@@ -214,7 +304,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -241,6 +331,39 @@ version = "0.3.4"
 source = "git+https://github.com/AnimaGUS-minerva/utils.git?branch=allow-hash-comments-in-hex#a849b0040f462173f38e59cd2bba7b4a2a00c05c"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +374,15 @@ name = "libc"
 version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "log"
@@ -284,7 +416,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -424,6 +556,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +697,7 @@ name = "rooster"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "custom_error",
  "futures",
  "hex-literal",
@@ -578,6 +730,12 @@ dependencies = [
  "thiserror",
  "tokio",
 ]
+
+[[package]]
+name = "scratch"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sharded-slab"
@@ -675,6 +833,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +878,17 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -864,9 +1042,69 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "winapi"
@@ -883,6 +1121,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +438,12 @@ name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "paste"
@@ -544,6 +560,8 @@ dependencies = [
  "structopt",
  "tokio",
  "tokio-test",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -559,6 +577,15 @@ dependencies = [
  "nix 0.22.3",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -677,6 +704,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tokio"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +769,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +843,12 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono     = "*"
 socket2    = { version = "0.3", features = [ "pair", "unix", "reuseport" ] }
 nix        = { version = "0.19" }
 moz_cbor   = { git = "https://github.com/AnimaGUS-minerva/cbor-rust.git", branch = "implement-strings" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ netlink-packet-sock-diag = "*"
 netlink-packet-route = { version = "*" }
 custom_error  = "*"
 rand = { version = "0.8.5", features = ["small_rng"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
 
 [dev-dependencies]
 tokio-test    = "0.4.2"

--- a/src/acp_interface.rs
+++ b/src/acp_interface.rs
@@ -56,13 +56,14 @@ pub const BRSKI_HTTP_OBJECTIVE: &str = "BRSKI";
 pub const BRSKI_COAP_OBJECTIVE: &str = "BRSKI_JP";
 pub const BRSKI_JPY_OBJECTIVE:  &str = "BRSKI_RJP";
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Debug,Copy, Clone, PartialEq)]
 pub enum RegistrarType {
     HTTPRegistrar{tcp_port: u16},
     CoAPRegistrar{udp_port: u16},
     StatelessCoAPRegistrar{udp_port: u16},
 }
 
+#[derive(Debug)]
 pub struct Registrar {
     pub rtypes: Vec<RegistrarType>,
     pub addr: IpAddr,
@@ -76,6 +77,7 @@ impl Registrar {
     }
 }
 
+#[derive(Debug)]
 pub struct AcpInterface {
     pub sock: UdpSocket,
     pub debug: Arc<DebugOptions>,

--- a/src/acp_interface.rs
+++ b/src/acp_interface.rs
@@ -571,7 +571,7 @@ pub mod tests {
         assert_eq!(aifn.calculate_available_registrar().await, (true, true, true));
 
         // now see about looking for a registrar to use.
-
+        //let target_acp = allif.;
         Ok(())
     }
 

--- a/src/debugoptions.rs
+++ b/src/debugoptions.rs
@@ -22,8 +22,10 @@ use futures::lock::Mutex;
 
 #[derive(Clone, Debug)]
 pub struct DebugOptions {
-    pub debug_interfaces:  bool,
-    pub verydebug_interfaces:  bool,
+    pub debug_interfaces:      bool,       // interfaces added/removed
+    pub debug_registrars:      bool,       // registrars announces
+    pub debug_joininterfaces:  bool,       // join interface announcements
+    pub debug_proxyactions:    bool,       // proxy connections and activity
     pub debug_output:      Arc<Mutex<dyn Write + Send>>
 }
 
@@ -31,24 +33,58 @@ impl DebugOptions {
     pub fn default() -> DebugOptions {
         DebugOptions {
             debug_interfaces:  false,
-            verydebug_interfaces:  false,
+            debug_registrars:  false,
+            debug_joininterfaces:  false,
+            debug_proxyactions:    false,
             debug_output:      Arc::new(Mutex::new(io::stdout()))
         }
     }
 
-    pub async fn debug_verbose(self: &Self,
+    pub async fn debug_interfaces(self: &Self,
                                msg: String) {
         if self.debug_interfaces {
             let mut output = self.debug_output.lock().await;
-            writeln!(output, "D: {}", msg).unwrap();
+            writeln!(output, "I: {}", msg).unwrap();
         }
     }
 
-    pub async fn debug_detailed(self: &Self,
-                               msg: String) {
-        if self.verydebug_interfaces {
+    pub async fn debug_interfaces_detailed(self: &Self,
+                                           msg: String) {
+        if self.debug_interfaces {
             let mut output = self.debug_output.lock().await;
-            writeln!(output, "V: {}", msg).unwrap();
+            writeln!(output, "I: {}", msg).unwrap();
+        }
+    }
+
+    pub async fn debug_registrars(self: &Self,
+                               msg: String) {
+        if self.debug_registrars {
+            let mut output = self.debug_output.lock().await;
+            writeln!(output, "R: {}", msg).unwrap();
+        }
+    }
+
+    pub async fn debug_registrars_detailed(self: &Self,
+                                           msg: String) {
+        if self.debug_registrars {
+            let mut output = self.debug_output.lock().await;
+            writeln!(output, "R: {}", msg).unwrap();
+        }
+    }
+
+    pub async fn debug_joininterfaces(self: &Self,
+                                      msg: String) {
+        if self.debug_joininterfaces {
+            let mut output = self.debug_output.lock().await;
+            writeln!(output, "J: {}", msg).unwrap();
+        }
+    }
+
+    pub async fn debug_proxyactions(self: &Self,
+                                    msg: String) {
+        if self.debug_proxyactions {
+            let mut output = self.debug_output.lock().await;
+            writeln!(output, "P: {}", msg).unwrap();
         }
     }
 
@@ -89,7 +125,9 @@ pub mod tests {
         let writer: Vec<u8> = vec![];
         let awriter = Arc::new(Mutex::new(writer));
         let db1 = DebugOptions { debug_interfaces: true,
-                                 verydebug_interfaces: false,
+                                 debug_registrars:  false,
+                                 debug_joininterfaces:  false,
+                                 debug_proxyactions:    false,
                                  debug_output: awriter.clone() };
 
         aw!(atest_debug_info(awriter.clone(), db1)).unwrap();
@@ -101,6 +139,6 @@ pub mod tests {
 /*
  * Local Variables:
  * mode: rust
- * compile-command: "cd .. && RUSTFLAGS='-A dead_code -Awarnings' cargo build"
+ * compile-command: "cd .. && cargo test"
  * End:
  */

--- a/src/debugoptions.rs
+++ b/src/debugoptions.rs
@@ -57,6 +57,12 @@ impl DebugOptions {
         let mut output = self.debug_output.lock().await;
         writeln!(output, "I: {}", msg).unwrap();
     }
+
+    pub async fn debug_error(self: &Self,
+                             msg: String) {
+        let mut output = self.debug_output.lock().await;
+        writeln!(output, "E: {}", msg).unwrap();
+    }
 }
 
 #[cfg(test)]

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -34,6 +34,7 @@ use crate::debugoptions::DebugOptions;
 use crate::args::RoosterOptions;
 use crate::grasp::SessionID;
 use crate::interfaces::ProxiesEnabled;
+use crate::interfaces::AllInterfaces;
 use crate::acp_interface::AcpInterface;
 use crate::join_interface::JoinInterface;
 
@@ -101,13 +102,15 @@ impl Interface {
     }
 
     pub async fn start_joinlink(self: &mut Self,
+                                lallif:    Arc<Mutex<AllInterfaces>>,
                                 _options: &RoosterOptions,
                                 mydebug: Arc<DebugOptions>,
                                 invalidate: Arc<Mutex<bool>>) {
 
         mydebug.debug_info(format!("starting JoinProxy announcer on joinlink interface {}", self.ifname)).await;
         self.join_daemon = Some(
-            JoinInterface::start_daemon(&self, invalidate.clone()).await.unwrap());
+            JoinInterface::start_daemon(&self, lallif,
+                                        invalidate.clone()).await.unwrap());
     }
 }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -135,7 +135,9 @@ pub mod tests {
         let writer: Vec<u8> = vec![];
         let awriter = Arc::new(Mutex::new(writer));
         let db1 = DebugOptions { debug_interfaces: true,
-                                 verydebug_interfaces: false,
+                                 debug_registrars:  false,
+                                 debug_joininterfaces:  false,
+                                 debug_proxyactions:    false,
                                  debug_output: awriter.clone() };
         let mut all1 = AllInterfaces::default();
         all1.debug = Arc::new(db1);

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -427,7 +427,9 @@ impl AllInterfaces {
     }
 
     pub async fn locked_pick_available_https_registrar(lallif: Arc<Mutex<AllInterfaces>>) -> Option<SocketAddr> {
+        println!("locked getting lock");
         let allif = lallif.lock().await;
+        println!("locked got lock");
         return allif.pick_available_https_registrar().await;
     }
 

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -56,7 +56,6 @@ use crate::args::RoosterOptions;
 use crate::interface::Interface;
 use crate::interface::IfIndex;
 use crate::acp_interface::{RegistrarType};
-use crate::grasp::SessionID;
 
 #[derive(Clone, Copy, Debug)]
 pub struct ProxiesEnabled {

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -292,11 +292,20 @@ impl AllInterfaces {
         debug.debug_info(format!("scanning existing interfaces")).await;
 
         while let Some(link) = list.try_next().await.unwrap() {
-            debug.debug_info(format!("scan message {}", cnt)).await;
+            debug.debug_info(format!("link message {}", cnt)).await;
             AllInterfaces::gather_link_info(&lallif,
                                             &options,
                                             debugextra.clone(),
                                             link).await.unwrap();
+            cnt += 1;
+        }
+
+        let mut list = handle.address().get().execute();
+        while let Some(addr) = list.try_next().await.unwrap() {
+            debug.debug_info(format!("addr message {}", cnt)).await;
+            AllInterfaces::gather_addr_info(&lallif,
+                                            &options,
+                                            addr).await.unwrap();
             cnt += 1;
         }
         Ok(())

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -409,7 +409,9 @@ impl AllInterfaces {
             let ifn = lifn.lock().await;
             if let Some(lai) = &ifn.acp_daemon {
                 let ai = lai.lock().await;
+                //println!("searching {:?}", ai);
                 for reg in &ai.registrars {
+                    //println!("reg searching {:?}", reg);
                     for rtype in &reg.rtypes {
                         match rtype {
                             RegistrarType::HTTPRegistrar{tcp_port: port} => {
@@ -728,6 +730,12 @@ pub mod tests {
         let output = awriter.lock().await;
         let stuff = std::str::from_utf8(&output).unwrap();
         println!("{}",stuff);
+
+        // now pick a registrar from the available ones, returning the SocketAddr for it.
+        assert_eq!(allif.pick_available_https_registrar().await,
+                   Some(std::net::SocketAddr::new(
+                       "fda3:79a6:f6ee:0:200:0:6400:1".parse::<IpAddr>().unwrap(),
+                       8993)));
 
         Ok(())
     }

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -27,6 +27,7 @@
 use std::net::{Ipv6Addr, IpAddr, SocketAddr};
 use std::collections::HashMap;
 use std::sync::Arc;
+use chrono;
 use futures::lock::Mutex;
 use futures::stream::StreamExt;
 use futures::TryStreamExt;

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -406,10 +406,12 @@ impl AllInterfaces {
 
     pub async fn pick_available_https_registrar(self: &AllInterfaces) -> Option<SocketAddr> {
         for lifn in self.acp_interfaces.values() {
+            //println!("interfaces locking {:?}", chrono::offset::Local::now());
             let ifn = lifn.lock().await;
             if let Some(lai) = &ifn.acp_daemon {
+                //println!("acp_interfaces locking {:?}", chrono::offset::Local::now());
                 let ai = lai.lock().await;
-                //println!("searching {:?}", ai);
+                //println!("searching {:?} at {:?}", ai, chrono::offset::Local::now());
                 for reg in &ai.registrars {
                     //println!("reg searching {:?}", reg);
                     for rtype in &reg.rtypes {
@@ -427,10 +429,12 @@ impl AllInterfaces {
     }
 
     pub async fn locked_pick_available_https_registrar(lallif: Arc<Mutex<AllInterfaces>>) -> Option<SocketAddr> {
-        println!("locked getting lock");
+        //println!("locked getting lock {:?}", chrono::offset::Local::now());
         let allif = lallif.lock().await;
-        println!("locked got lock");
-        return allif.pick_available_https_registrar().await;
+        //println!("locked got lock {:?}", chrono::offset::Local::now());
+        let reg = allif.pick_available_https_registrar().await;
+        println!("picked registrar: {:?}", reg);
+        return reg;
     }
 
 

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -27,7 +27,7 @@
 use std::net::{Ipv6Addr, IpAddr, SocketAddr};
 use std::collections::HashMap;
 use std::sync::Arc;
-use chrono;
+//use chrono;
 use futures::lock::Mutex;
 use futures::stream::StreamExt;
 use futures::TryStreamExt;

--- a/src/join_interface.rs
+++ b/src/join_interface.rs
@@ -160,7 +160,7 @@ impl JoinInterface {
 
         if proxies.http_avail {
             self.debug.debug_verbose(format!("HTTP Registrar at {}:{}",
-                                             self.https_v6addr, self.https_port)).await;
+                                             initiator, self.https_port)).await;
             gm.objectives.push(GraspObjective { objective_name: "AN_Proxy".to_string(),
                                                 objective_flags: 0,
                                                 loop_count: 1,
@@ -201,7 +201,8 @@ impl JoinInterface {
             }
         };
 
-        self.debug.debug_verbose("sending GRASP DULL message".to_string()).await;
+        self.debug.debug_verbose(
+            format!("sending GRASP DULL message about port {]", self.https_port)).await;
         // now write it to socket.
         let graspdest = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xff02, 0,
                                                                  0,0,
@@ -220,6 +221,8 @@ impl JoinInterface {
             let ji = lji.lock().await;
             ji.debug.clone()
         };
+
+        debug.debug_info(format!("new pledge {} looking for Registrar", pledgeaddr)).await;
 
         // need to find a useful Registrar to connect to.
         if let Some(target_sockaddr) = AllInterfaces::locked_pick_available_https_registrar(lallif).await {

--- a/src/join_interface.rs
+++ b/src/join_interface.rs
@@ -202,7 +202,7 @@ impl JoinInterface {
         };
 
         self.debug.debug_verbose(
-            format!("sending GRASP DULL message about port {]", self.https_port)).await;
+            format!("sending GRASP DULL message about port {}", self.https_port)).await;
         // now write it to socket.
         let graspdest = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xff02, 0,
                                                                  0,0,

--- a/src/join_interface.rs
+++ b/src/join_interface.rs
@@ -236,6 +236,7 @@ impl JoinInterface {
                     debug.debug_info(format!("copied {} / {} bytes between streams", n1,n2)).await;
                     return Ok(())
                 },
+                Err(e) if e.kind() == std::io::ErrorKind::NotConnected => { return Ok(()) },
                 Err(e)   => {
                     debug.debug_error(
                         format!("did not connect to Registrar: {}",e)).await;

--- a/src/join_interface.rs
+++ b/src/join_interface.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 use futures::lock::Mutex;
 //use tokio::process::{Command};
 use socket2::{Socket, Domain, Type};
-use netlink_packet_sock_diag::constants::{IPPROTO_TCP, IPPROTO_UDP};
+use netlink_packet_sock_diag::constants::{IPPROTO_TCP};
 
 //use cbor::decoder::decode as cbor_decode;
 

--- a/src/join_interface.rs
+++ b/src/join_interface.rs
@@ -222,8 +222,12 @@ impl JoinInterface {
 
         debug.debug_info(format!("new pledge {} looking for Registrar", pledgeaddr)).await;
 
+        let some_target = AllInterfaces::locked_pick_available_https_registrar(lallif).await;
+
+        debug.debug_info(format!("new pledge {} found a Registrar {:?}", pledgeaddr, some_target)).await;
+
         // need to find a useful Registrar to connect to.
-        if let Some(target_sockaddr) = AllInterfaces::locked_pick_available_https_registrar(lallif).await {
+        if let Some(target_sockaddr) = some_target {
             debug.debug_info(format!("new pledge {} connects to {}", pledgeaddr, target_sockaddr)).await;
             match TcpStream::connect(target_sockaddr).await {
                 Ok(mut conn) => {

--- a/src/join_interface.rs
+++ b/src/join_interface.rs
@@ -159,8 +159,8 @@ impl JoinInterface {
         };
 
         if proxies.http_avail {
-            self.debug.debug_verbose(format!("HTTP Registrar at {}:{}",
-                                             initiator, self.https_port)).await;
+            self.debug.debug_joininterfaces(format!("HTTP Registrar at {}:{}",
+                                                    initiator, self.https_port)).await;
             gm.objectives.push(GraspObjective { objective_name: "AN_Proxy".to_string(),
                                                 objective_flags: 0,
                                                 loop_count: 1,
@@ -201,7 +201,7 @@ impl JoinInterface {
             }
         };
 
-        self.debug.debug_verbose(
+        self.debug.debug_joininterfaces(
             format!("sending GRASP DULL message about port {}", self.https_port)).await;
         // now write it to socket.
         let graspdest = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xff02, 0,
@@ -266,11 +266,11 @@ impl JoinInterface {
             let mut cnt: u32 = 0;
 
             loop {
-                debug.debug_verbose(format!("{} join loop: {:?}", cnt, https_listen_sock)).await;
+                debug.debug_joininterfaces(format!("{} join loop: {:?}", cnt, https_listen_sock)).await;
 
                 match https_listen_sock.accept().await {
                     Ok((socket, addr)) => {
-                        debug.debug_verbose(format!("new pledge client from: {:?} on {:?}",
+                        debug.debug_joininterfaces(format!("new pledge client from: {:?} on {:?}",
                                                     addr, socket)).await;
                         let ji3 = jil.clone();
                         let lallif3 = lallif.clone();
@@ -313,7 +313,9 @@ pub mod tests {
         let writer: Vec<u8> = vec![];
         let awriter = Arc::new(Mutex::new(writer));
         let db1 = DebugOptions { debug_interfaces: true,
-                                 verydebug_interfaces: false,
+                                 debug_registrars:  false,
+                                 debug_joininterfaces:  false,
+                                 debug_proxyactions:    false,
                                  debug_output: awriter.clone() };
         let mut all1 = AllInterfaces::default();
         all1.debug = Arc::new(db1);

--- a/src/join_interface.rs
+++ b/src/join_interface.rs
@@ -201,8 +201,6 @@ impl JoinInterface {
             }
         };
 
-        self.debug.debug_joininterfaces(
-            format!("sending GRASP DULL message about port {}", self.https_port)).await;
         // now write it to socket.
         let graspdest = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xff02, 0,
                                                                  0,0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,11 @@ use crate::interfaces::AllInterfaces;
 #[tokio::main(flavor = "multi_thread", worker_threads = 10)]
 async fn main() {
 
+    // construct a subscriber that prints formatted traces to stdout
+    let subscriber = tracing_subscriber::FmtSubscriber::new();
+    // use that subscriber to process traces emitted after this point
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
     // process the arguments to find out which interface is the uplink
     // interface.
     let mainargs = RoosterOptions::from_args();

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ async fn main() {
 
     let mut done = false;
     while !done {
-        sleep(Duration::from_millis(10000)).await;
+        sleep(Duration::from_millis(5000)).await;
 
         debug.debug_verbose(format!("{} main loop", main_loopcount)).await;
         main_loopcount += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ async fn main() {
     while !done {
         sleep(Duration::from_millis(5000)).await;
 
-        debug.debug_verbose(format!("{} main loop", main_loopcount)).await;
+        debug.debug_info(format!("{} main loop", main_loopcount)).await;
         main_loopcount += 1;
 
         done = {

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,16 +89,20 @@ async fn main() {
                 doneinterface.update_available_registrars().await;
                 (doneinterface.joinlink_interfaces.clone(), doneinterface.proxies.clone(), doneinterface.exitnow)
             };
+            //debug.debug_info(format!("{} join iteration acquired", main_loopcount)).await;
             // doneinterface lock is released here.
             let ji_hash = lji_hash.lock().await;
 
+            //debug.debug_info(format!("{} join iteration locked", main_loopcount)).await;
             for ljl in ji_hash.values() {
+                //debug.debug_info(format!("{} taking ljk lock", main_loopcount)).await;
                 let jl = ljl.lock().await;
                 let session_id = rand::random::<u32>();
                 jl.registrar_all_announce(proxies.clone(),
                                           session_id).await.unwrap();
             }
 
+            //debug.debug_info(format!("{} join iteration unlocking", main_loopcount)).await;
             isitdone
         };
         debug.debug_info(format!("{} end main loop", main_loopcount)).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,11 +48,17 @@ async fn main() {
     println!("Read in args: {:?}\n", mainargs);
 
     let mut debug_options = crate::debugoptions::DebugOptions::default();
-    if mainargs.debug_graspmessages {
+    if mainargs.debug_interfaces {
         debug_options.debug_interfaces = true;
     }
-    if mainargs.debug_interfacedetail {
-        debug_options.verydebug_interfaces = true;
+    if mainargs.debug_registrars {
+        debug_options.debug_registrars = true;
+    }
+    if mainargs.debug_joininterfaces {
+        debug_options.debug_joininterfaces = true;
+    }
+    if mainargs.debug_proxyactions {
+        debug_options.debug_proxyactions   = true;
     }
     println!("Debug Interfaces is {}", debug_options.debug_interfaces);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ pub mod error;
 use crate::args::RoosterOptions;
 use crate::interfaces::AllInterfaces;
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread", worker_threads = 10)]
 async fn main() {
 
     // process the arguments to find out which interface is the uplink
@@ -67,8 +67,8 @@ async fn main() {
     while !done {
         sleep(Duration::from_millis(5000)).await;
 
-        debug.debug_info(format!("{} main loop", main_loopcount)).await;
         main_loopcount += 1;
+        debug.debug_info(format!("{} main loop", main_loopcount)).await;
 
         done = {
             let mut doneinterface = interface.lock().await;
@@ -82,7 +82,8 @@ async fn main() {
             }
 
             doneinterface.exitnow
-        }
+        };
+        debug.debug_info(format!("{} end main loop", main_loopcount)).await;
     }
 }
 


### PR DESCRIPTION
This code set adjusts many issues surrounding locking so that the join_interface loop can effectively search the required ACP Registrar lists to find an available Registrar to connect to.
There are still some issues with the tokio IO copy loop where it complains if one socket gets closed too quickly.
